### PR TITLE
fx: no ignored replay buffer rule does not check supplied config for buffer size

### DIFF
--- a/packages/eslint-plugin-rxjs/docs/rules/no-ignored-replay-buffer.md
+++ b/packages/eslint-plugin-rxjs/docs/rules/no-ignored-replay-buffer.md
@@ -11,6 +11,11 @@ import { ReplaySubject } from "rxjs";
 const subject = new ReplaySubject<number>();
 ```
 
+```ts
+import { of, shareReplay } from "rxjs";
+of(42).pipe(shareReplay({ refCount: true }));
+```
+
 Examples of **correct** code for this rule:
 
 ```ts
@@ -21,6 +26,11 @@ const subject = new ReplaySubject<number>(1);
 ```ts
 import { ReplaySubject } from "rxjs";
 const subject = new ReplaySubject<number>(Infinity);
+```
+
+```ts
+import { of, shareReplay } from "rxjs";
+of(42).pipe(shareReplay({ refCount: true, bufferSize: 1 }));
 ```
 
 ## Options

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-ignored-replay-buffer.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-ignored-replay-buffer.ts
@@ -2,6 +2,9 @@ import { AST_NODE_TYPES, TSESTree as es } from '@typescript-eslint/utils';
 
 import { ESLintUtils } from '@typescript-eslint/utils';
 
+// Thanks to JaxonWinzierl for helping with the fix for the config
+// https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/pull/12/files#diff-8a9cff9aa21d1a4600766e85f1493aa81fa30c4902d6110c21173d00536393ed
+
 export const messageId = 'forbidden';
 export default ESLintUtils.RuleCreator(() => __filename)({
   meta: {

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-ignored-replay-buffer.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-ignored-replay-buffer.ts
@@ -1,5 +1,4 @@
-import { TSESTree as es } from '@typescript-eslint/utils';
-import { getParent } from '../eslint-etc';
+import { AST_NODE_TYPES, TSESTree as es } from '@typescript-eslint/utils';
 
 import { ESLintUtils } from '@typescript-eslint/utils';
 
@@ -21,15 +20,41 @@ export default ESLintUtils.RuleCreator(() => __filename)({
   name: 'no-ignored-replay-buffer',
   defaultOptions: [],
   create: (context) => {
+    function checkShareReplayConfig(
+      node: es.Identifier,
+      shareReplayConfigArg: es.ObjectExpression,
+    ) {
+      if (
+        !shareReplayConfigArg.properties.some(
+          (p) =>
+            p.type === AST_NODE_TYPES.Property &&
+            p.key.type === AST_NODE_TYPES.Identifier &&
+            p.key.name === 'bufferSize',
+        )
+      ) {
+        context.report({
+          messageId: 'forbidden',
+          node,
+        });
+      }
+    }
+
     function checkNode(
-      node: es.Node,
-      { arguments: args }: { arguments: es.Node[] },
+      node: es.Identifier,
+      { arguments: args }: es.NewExpression | es.CallExpression,
     ) {
       if (!args || args.length === 0) {
         context.report({
-          messageId,
+          messageId: 'forbidden',
           node,
         });
+      }
+
+      if (node.name === 'shareReplay' && args?.length === 1) {
+        const arg = args[0];
+        if (arg.type === AST_NODE_TYPES.ObjectExpression) {
+          checkShareReplayConfig(node, arg);
+        }
       }
     }
 
@@ -37,22 +62,28 @@ export default ESLintUtils.RuleCreator(() => __filename)({
       "NewExpression > Identifier[name='ReplaySubject']": (
         node: es.Identifier,
       ) => {
-        const newExpression = getParent(node) as es.NewExpression;
+        const newExpression = node.parent as es.NewExpression;
         checkNode(node, newExpression);
       },
       "NewExpression > MemberExpression > Identifier[name='ReplaySubject']": (
         node: es.Identifier,
       ) => {
-        const memberExpression = getParent(node) as es.MemberExpression;
-        const newExpression = getParent(memberExpression) as es.NewExpression;
+        const memberExpression = node.parent as es.MemberExpression;
+        const newExpression = memberExpression.parent as es.NewExpression;
         checkNode(node, newExpression);
       },
       'CallExpression > Identifier[name=/^(publishReplay|shareReplay)$/]': (
         node: es.Identifier,
       ) => {
-        const callExpression = getParent(node) as es.CallExpression;
+        const callExpression = node.parent as es.CallExpression;
         checkNode(node, callExpression);
       },
+      'CallExpression > MemberExpression > Identifier[name=/^(publishReplay|shareReplay)$/]':
+        (node: es.Identifier) => {
+          const memberExpression = node.parent as es.MemberExpression;
+          const callExpression = memberExpression.parent as es.CallExpression;
+          checkNode(node, callExpression);
+        },
     };
   },
 });

--- a/packages/eslint-plugin-rxjs/src/lib/tests/rules/no-ignored-replay-buffer.spec.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/tests/rules/no-ignored-replay-buffer.spec.ts
@@ -27,6 +27,11 @@ ruleTester.run('no-ignored-replay-buffer', rule, {
       const a = of(42).pipe(shareReplay(1));
     `,
     `
+      // shareReplay with config not ignored
+      import { interval, shareReplay } from "rxjs";
+      interval(1000).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    `,
+    `
       // namespace ReplaySubject not ignored
       import * as Rx from "rxjs";
 
@@ -48,6 +53,12 @@ ruleTester.run('no-ignored-replay-buffer', rule, {
       const a = Rx.of(42).pipe(shareReplay(1));
     `,
     `
+      // namespace shareReplay with config not ignored
+      import * as Rx from "rxjs";
+      import { shareReplay } from "rxjs/operators";
+      const a = Rx.of(42).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    `,
+    `
       // namespace class not ignored
       import * as Rx from "rxjs";
 
@@ -57,6 +68,11 @@ ruleTester.run('no-ignored-replay-buffer', rule, {
           this.valid = new Rx.ReplaySubject<number>(1);
         }
       }
+    `,
+    `
+        // shareReplay with config not ignored
+        import { interval, shareReplay } from "rxjs";
+        interval(1000).pipe(shareReplay({ bufferSize: 1, refCount: true }));
     `,
   ],
   invalid: [
@@ -103,7 +119,26 @@ ruleTester.run('no-ignored-replay-buffer', rule, {
                               ~~~~~~~~~~~
       `,
     }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'shareReplay with config ignored',
+      messageId,
+      annotatedSource: `
+        // shareReplay with config ignored
+        import { of, shareReplay } from "rxjs";
+        const a = of(42).pipe(shareReplay({ refCount: true }));
+                              ~~~~~~~~~~~
+      `,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'shareReplay with config ignored',
+      messageId,
+      annotatedSource: `
+        import { interval, shareReplay } from "rxjs";
 
+        interval(1000).pipe(shareReplay({ refCount: true }));
+                            ~~~~~~~~~~~
+      `,
+    }),
     convertAnnotatedSourceToFailureCase({
       description: 'namespace ReplaySubject ignored a',
       messageId,
@@ -145,6 +180,16 @@ ruleTester.run('no-ignored-replay-buffer', rule, {
 
         const a = Rx.of(42).pipe(shareReplay());
                                  ~~~~~~~~~~~
+      `,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'namespace shareReplay with config ignored',
+      messageId,
+      annotatedSource: `
+        import * as Rx from "rxjs";
+
+        const a = Rx.of(42).pipe(Rx.shareReplay({ refCount: true }));
+                                    ~~~~~~~~~~~
       `,
     }),
     convertAnnotatedSourceToFailureCase({


### PR DESCRIPTION
# Issue Number: #37 

# Body

Now fails on config files that have no bufferSize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the `no-ignored-replay-buffer` ESLint rule
	- Added code examples demonstrating correct and incorrect usage of `shareReplay`

- **New Features**
	- Enhanced ESLint rule to validate `bufferSize` configuration in `shareReplay` function calls
	- Improved linting process for RxJS replay buffer implementations

- **Tests**
	- Added new test cases for `shareReplay` configuration scenarios
	- Expanded test coverage for the ESLint rule

<!-- end of auto-generated comment: release notes by coderabbit.ai -->