### PR TITLE
fix: update no-implicit-any-catch to handle 2 parameters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "nxConsole.generateAiAgentRules": true
+}

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,13 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "tui": {
+    "enabled": false
+  },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/.eslintrc.json",
@@ -19,8 +25,13 @@
   "targetDefaults": {
     "@nx/esbuild:esbuild": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
     "lint": {
       "inputs": [
@@ -33,7 +44,11 @@
     },
     "@nx/jest:jest": {
       "cache": true,
-      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/jest.preset.js"
+      ],
       "options": {
         "passWithNoTests": true
       },

--- a/packages/eslint-plugin-rxjs/src/lib/tests/rules/no-implicit-any-catch.spec.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/tests/rules/no-implicit-any-catch.spec.ts
@@ -57,6 +57,17 @@ ruleTester.run('no-implicit-any-catch', rule, {
     },
     {
       code: `
+        // non-arrow; explicit unknown; default option
+        import { throwError } from "rxjs";
+        import { catchError } from "rxjs/operators";
+
+        throwError("Kaboom!").pipe(
+          catchError(function (error: unknown, caught: Observable<unknown>) { console.error(error); })
+        );
+      `,
+    },
+    {
+      code: `
         // arrow; explicit unknown; explicit option
         import { throwError } from "rxjs";
         import { catchError } from "rxjs/operators";
@@ -210,6 +221,30 @@ ruleTester.run('no-implicit-any-catch', rule, {
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
+      description: 'arrow; implicit any; 2 parameters',
+      messageId: implicitAnyId,
+      annotatedSource: `
+        // arrow; implicit any; 2 parameters
+        import { throwError } from "rxjs";
+        import { catchError } from "rxjs/operators";
+
+        throwError("Kaboom!").pipe(
+          catchError((error, caught) => console.error(error))
+                      ~~~~~//
+        );
+        `,
+      annotatedOutput: `
+        // arrow; implicit any; 2 parameters
+        import { throwError } from "rxjs";
+        import { catchError } from "rxjs/operators";
+
+        throwError("Kaboom!").pipe(
+          catchError((error: unknown, caught) => console.error(error))
+                      //
+        );
+        `,
+    }),
+    convertAnnotatedSourceToFailureCase({
       description: 'arrow; implicit any',
       messageId: implicitAnyId,
       annotatedSource: `
@@ -325,6 +360,30 @@ ruleTester.run('no-implicit-any-catch', rule, {
       `,
         },
       ],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'non-arrow; implicit any; 2 parameters',
+      messageId: implicitAnyId,
+      annotatedSource: `
+        // non-arrow; implicit any; 2 parameters
+        import { throwError } from "rxjs";
+        import { catchError } from "rxjs/operators";
+
+        throwError("Kaboom!").pipe(
+          catchError(function (error, caught) { console.error(error); })
+                               ~~~~~//
+          );
+      `,
+      annotatedOutput: `
+        // non-arrow; implicit any; 2 parameters
+        import { throwError } from "rxjs";
+        import { catchError } from "rxjs/operators";
+
+        throwError("Kaboom!").pipe(
+          catchError(function (error: unknown, caught) { console.error(error); })
+                               //
+          );
+      `,
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'arrow; explicit any; default option',


### PR DESCRIPTION
# Issue Number: #176 

# Body

Updated code and tests for no-implicit-any-catch so that it also handles 2 parameters in the catch callback.