### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/packages/eslint-plugin-rxjs/src/lib/rules/ban-observables.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/ban-observables.ts
@@ -21,6 +21,12 @@ export default ESLintUtils.RuleCreator(
       {
         type: 'object',
         description: `An object containing keys that are names of observable factory functions and values that are either booleans or strings containing the explanation for the ban.`,
+        additionalProperties: {
+          anyOf: [
+            {type: 'boolean'},
+            {type: 'string'},
+          ]
+        },
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/ban-operators.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/ban-operators.ts
@@ -21,6 +21,12 @@ export default ESLintUtils.RuleCreator(
       {
         type: 'object',
         description: `An object containing keys that are names of operators and values that are either booleans or strings containing the explanation for the ban.`,
+        additionalProperties: {
+          anyOf: [
+            {type: 'boolean'},
+            {type: 'string'},
+          ]
+        },
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/finnish.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/finnish.ts
@@ -49,6 +49,7 @@ export default ESLintUtils.RuleCreator(
           variables: { type: 'boolean' },
         },
         type: 'object',
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/finnish.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/finnish.ts
@@ -41,11 +41,21 @@ export default ESLintUtils.RuleCreator(
         properties: {
           functions: { type: 'boolean' },
           methods: { type: 'boolean' },
-          names: { type: 'object' },
+          names: { 
+            type: 'object',
+            additionalProperties: {
+              type: 'boolean',
+            },
+          },
           parameters: { type: 'boolean' },
           properties: { type: 'boolean' },
           strict: { type: 'boolean' },
-          types: { type: 'object' },
+          types: { 
+            type: 'object',
+            additionalProperties: {
+              type: 'boolean',
+            },
+          },
           variables: { type: 'boolean' },
         },
         type: 'object',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-cyclic-action.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-cyclic-action.ts
@@ -35,6 +35,7 @@ export default ESLintUtils.RuleCreator(
         },
         type: 'object',
         description: `An optional object with an optional \`observable\` property. The property can be specified as a regular expression string and is used to identify the action observables from which effects and epics are composed.`,
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-exposed-subjects.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-exposed-subjects.ts
@@ -32,6 +32,7 @@ export default ESLintUtils.RuleCreator(
           allowProtected: { type: 'boolean' },
         },
         type: 'object',
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-sharereplay.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-sharereplay.ts
@@ -28,6 +28,7 @@ export default ESLintUtils.RuleCreator(
           allowConfig: { type: 'boolean' },
         },
         type: 'object',
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-catch.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-catch.ts
@@ -34,6 +34,7 @@ export default ESLintUtils.RuleCreator(
         },
         type: 'object',
         description: `An optional object with an optional \`observable\` property. The property can be specified as a regular expression string and is used to identify the action observables from which effects and epics are composed.`,
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-first.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-first.ts
@@ -29,6 +29,7 @@ export default ESLintUtils.RuleCreator(
         },
         type: 'object',
         description: `An optional object with an optional \`observable\` property. The property can be specified as a regular expression string and is used to identify the action observables from which effects and epics are composed.`,
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-switchmap.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-switchmap.ts
@@ -56,6 +56,7 @@ export default ESLintUtils.RuleCreator(
         },
         type: 'object',
         description: `An optional object with optional \`allow\`, \`disallow\` and \`observable\` properties. The properties can be specified as regular expression strings or as arrays of words. The \`allow\` or \`disallow\` properties are mutually exclusive. Whether or not \`switchMap\` is allowed will depend upon the matching of action types with \`allow\` or \`disallow\`. The \`observable\` property is used to identify the action observables from which effects and epics are composed.`,
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-takeuntil.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/no-unsafe-takeuntil.ts
@@ -37,6 +37,7 @@ export default ESLintUtils.RuleCreator(
         },
         type: 'object',
         description: `An optional object with optional \`alias\` and \`allow\` properties. The \`alias\` property is an array containing the names of operators that aliases for \`takeUntil\`. The \`allow\` property is an array containing the names of the operators that are allowed to follow \`takeUntil\`.`,
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/prefer-observer.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/prefer-observer.ts
@@ -34,6 +34,7 @@ export default ESLintUtils.RuleCreator(
           allowNext: { type: 'boolean' },
         },
         type: 'object',
+        additionalProperties: false,
       },
     ],
     type: 'problem',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/suffix-subjects.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/suffix-subjects.ts
@@ -37,7 +37,12 @@ export default ESLintUtils.RuleCreator(
           parameters: { type: 'boolean' },
           properties: { type: 'boolean' },
           suffix: { type: 'string' },
-          types: { type: 'object' },
+          types: { 
+            type: 'object',
+            additionalProperties: {
+              type: 'boolean',
+            },
+          },
           variables: { type: 'boolean' },
         },
         type: 'object',

--- a/packages/eslint-plugin-rxjs/src/lib/rules/suffix-subjects.ts
+++ b/packages/eslint-plugin-rxjs/src/lib/rules/suffix-subjects.ts
@@ -41,6 +41,7 @@ export default ESLintUtils.RuleCreator(
           variables: { type: 'boolean' },
         },
         type: 'object',
+        additionalProperties: false,
       },
     ],
     type: 'problem',


### PR DESCRIPTION
<!--
Title:
The title should be in the form of type: subject, where type is one of the following:
- build: Changes that affect the build system or external dependencies
- ci: Changes to our CI configuration files and scripts
- docs: Documentation only changes
- feat: A new feature
- fix: A bug fix
- perf: A code change that improves performance
- refactor: A code change that neither fixes a bug nor adds a feature
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **tests**: Adding missing tests or correcting existing tests

Subject:
The subject contains a succinct description of the change:

- use the imperative, present tense: "change" not "changed" nor "changes"
- don't capitalize the first letter
- no dot (.) at the end
-->

# Issue Number: #<!-- issue number -->

# Body

Some rules, for example [no-cyclic-action](https://github.com/DaveMBush/eslint-plugin-rxjs/blob/fdc3f0814af76bd652350e5007dc1661dfbdf3c6/packages/eslint-plugin-rxjs/src/lib/rules/no-cyclic-action.ts#L32) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.

I've also updated the schemas of some rules to make them stricter.
